### PR TITLE
Debertav2 fast change vocab

### DIFF
--- a/src/transformers/models/deberta_v2/tokenization_deberta_v2_fast.py
+++ b/src/transformers/models/deberta_v2/tokenization_deberta_v2_fast.py
@@ -139,12 +139,6 @@ class DebertaV2TokenizerFast(PreTrainedTokenizerFast):
             **kwargs,
         )
 
-        if not os.path.isfile(vocab_file):
-            raise ValueError(
-                f"Can't find a vocabulary file at path '{vocab_file}'. To load the vocabulary from a Google pretrained "
-                "model use `tokenizer = AutoTokenizer.from_pretrained(PRETRAINED_MODEL_NAME)`"
-            )
-
         self.do_lower_case = do_lower_case
         self.vocab_file = vocab_file
         self.can_save_slow_tokenizer = False if not self.vocab_file else True

--- a/src/transformers/models/deberta_v2/tokenization_deberta_v2_fast.py
+++ b/src/transformers/models/deberta_v2/tokenization_deberta_v2_fast.py
@@ -30,6 +30,8 @@ else:
 
 logger = logging.get_logger(__name__)
 
+VOCAB_FILES_NAMES = {"vocab_file": "spm.model", "tokenizer_file": "tokenizer.json"}
+
 PRETRAINED_VOCAB_FILES_MAP = {
     "vocab_file": {
         "microsoft/deberta-v2-xlarge": "https://huggingface.co/microsoft/deberta-v2-xlarge/resolve/main/spm.model",
@@ -52,8 +54,6 @@ PRETRAINED_INIT_CONFIGURATION = {
     "microsoft/deberta-v2-xlarge-mnli": {"do_lower_case": False},
     "microsoft/deberta-v2-xxlarge-mnli": {"do_lower_case": False},
 }
-
-VOCAB_FILES_NAMES = {"vocab_file": "spm.model"}
 
 
 class DebertaV2TokenizerFast(PreTrainedTokenizerFast):


### PR DESCRIPTION
# What does this PR do?

In this PR I propose 2 changes to the [current PR](https://github.com/huggingface/transformers/pull/14928) to add a fast version to the deberta-v2 tokenizer. 

I propose to update the `VOCAB_FILES_NAMES`  variable, this change solves the test `DebertaV2TokenizationTest.test_saving_tokenizer_trainer`. 

I propose to remove a check which according to me is not adapted to the fast version of the tokenizer (this should solve the test `test_training_new_tokenizer_with_special_tokens_change`)

# Who can review?

@alcinos and @mingboiz :smile: 