### PR TITLE
changed slow tokenizer tokenize

### DIFF
--- a/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
@@ -321,16 +321,7 @@ class SPMTokenizer:
         self.spm.Load(self.vocab_file)
 
     def tokenize(self, text):
-        pieces = self._encode_as_pieces(text)
-
-        def _norm(x):
-            if x not in self.vocab or x == "<unk>":
-                return "[UNK]"
-            else:
-                return x
-
-        pieces = [_norm(p) for p in pieces]
-        return pieces
+        return self._encode_as_pieces(text)
 
     def convert_ids_to_tokens(self, ids):
         tokens = []

--- a/tests/test_tokenization_deberta_v2.py
+++ b/tests/test_tokenization_deberta_v2.py
@@ -92,7 +92,7 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, keep_accents=True)
 
         tokens = tokenizer.tokenize("This is a test")
-        self.assertListEqual(tokens, ["▁", "T", "his", "▁is", "▁a", "▁test"]
+        self.assertListEqual(tokens, ["▁", "T", "his", "▁is", "▁a", "▁test"])
 
         self.assertListEqual(tokenizer.convert_tokens_to_ids(tokens), [13, 1, 4398, 25, 21, 1289])
 

--- a/tests/test_tokenization_deberta_v2.py
+++ b/tests/test_tokenization_deberta_v2.py
@@ -92,7 +92,7 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, keep_accents=True)
 
         tokens = tokenizer.tokenize("This is a test")
-        self.assertListEqual(tokens, ["▁", "[UNK]", "his", "▁is", "▁a", "▁test"])
+        self.assertListEqual(tokens, ["▁", "T", "his", "▁is", "▁a", "▁test"]
 
         self.assertListEqual(tokenizer.convert_tokens_to_ids(tokens), [13, 1, 4398, 25, 21, 1289])
 
@@ -100,7 +100,7 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         # fmt: off
         self.assertListEqual(
             tokens,
-            ["▁", "[UNK]", "▁was", "▁born", "▁in", "▁9", "2000", ",", "▁and", "▁this", "▁is", "▁fal", "s", "[UNK]", "."],
+            ["▁", "I", "▁was", "▁born", "▁in", "▁9", "2000", ",", "▁and", "▁this", "▁is", "▁fal", "s", "é", "."],
         )
         ids = tokenizer.convert_tokens_to_ids(tokens)
         self.assertListEqual(ids, [13, 1, 23, 386, 19, 561, 3050, 15, 17, 48, 25, 8256, 18, 1, 9])


### PR DESCRIPTION
# What does this PR do?

I pulled from @SaulLu's changes and then changed SPMTokenizer's tokenize() to ensure parity with Debertav2TokenizerFast's tokenize()

I have also changed the respective tests for the slow tokenizer to make it not spit out [UNK]

# Who can review?
@alcinos @SaulLu 